### PR TITLE
Increase maxBuffer to 100 MB

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -39,7 +39,10 @@ exports.handle = async function (event) {
     fs.writeFileSync(options, JSON.stringify(event));
 
     // Exec spatie's browser command.
-    let result = execSync(`node ./browser.js '-f file://${options}'`);
+    let result = execSync(`node ./browser.js '-f file://${options}'`, {
+        // Set maxBuffer to 100 MB
+        maxBuffer: 1024 * 1024 * 100
+    });
 
     // If there was a path, then read the file and return it.
     if (event.options.path) {


### PR DESCRIPTION
While using `sidecar-browsershot` in an app, I've noticed a couple of Lambda invocations which failed due to the following error:

```log
ERROR   Invoke Error    {
    "errorType": "Error",
    "errorMessage": "spawnSync /bin/sh ENOBUFS",
    "trace": [
        "Error: spawnSync /bin/sh ENOBUFS",
        "    at Object.spawnSync (internal/child_process.js:1077:20)",
        "    at spawnSync (child_process.js:776:24)",
        "    at execSync (child_process.js:858:15)",
        "    at Runtime.exports.handle [as handler] (/var/task/browsershot.js:42:18)",
        "    at processTicksAndRejections (internal/process/task_queues.js:95:5)"
    ]
}
```

This ususally happened when creating a full size screenshot of long websites. The issue could be locally fixed by setting the [maxBuffer](https://nodejs.org/api/child_process.html#maxbuffer-and-unicode) option of `child_process`.

---

I thought about making this value dynamic or equal to the value of `BrowsershotFunction@memory()`, but I think nobody will create screenshots or PDFs bigger than 100 MB in size with this Lambda function.