### PR TITLE
Browsershot 3.52.4 comptability

### DIFF
--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -31,6 +31,7 @@ class BrowsershotLambda extends Browsershot
 
         if ($path) {
             file_put_contents($path, base64_decode($response->body()));
+            return $path;
         } else {
             return $response->body();
         }

--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -11,7 +11,7 @@ use Wnx\SidecarBrowsershot\Functions\BrowsershotFunction;
 
 class BrowsershotLambda extends Browsershot
 {
-    protected function callBrowser(array $command)
+    protected function callBrowser(array $command): string
     {
         $url = Arr::get($command, 'url');
 


### PR DESCRIPTION
The [latest version of Browsershot](https://github.com/spatie/browsershot/commit/50eae920a25d3c5a7b771077d9c3469d56f22495) Adds a return typehint on `callBrowser` which results in a fatal error:

<img width="1137" alt="image" src="https://user-images.githubusercontent.com/7000886/161383456-bd7dd445-fff9-4ec5-a237-8df2f72b3768.png">


This PR adds the return typehint. 

For cases where the browsershot output is saved to file, the `$path` is returned.

