### PR TITLE
Add `sidecar-browsershot` config and warming support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ $html = BrowsershotLambda::url('https://example.com')->bodyHtml();
 Storage::disk('s3')->put('example.html', $html);
 ```
 
+## Warming
+
+sidecar-browsershot supports [warming](https://hammerstone.dev/sidecar/docs/main/functions/warming) for faster execution.
+
+To enable this feature set the `SIDECAR_BROWSERSHOT_WARMING_INSTANCES` variable in your `.env` to the desired number of instances Sidecar should warm for you.
+
+```shell
+SIDECAR_BROWSERSHOT_WARMING_INSTANCES=5
+```
+
+Alternatively you can publish the `sidecar-browsershot.php` config file and change the `warming` setting yourself.
+
 ## Testing
 
 The testsuite makes connections to AWS and runs the deployed Lambda function. In order to run the testsuite, you will need an active [AWS account](https://aws.amazon.com/).

--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ You can install the package via composer:
 composer require wnx/sidecar-browsershot
 ```
 
+You can publish the config file with:
+
+```bash
+php artisan vendor:publish --tag="sidecar-browsershot-config"
+```
+
 Register the `BrowsershotFunction::class` in your `sidecar.php` config file.
 
 ```php

--- a/config/sidecar-browsershot.php
+++ b/config/sidecar-browsershot.php
@@ -1,0 +1,9 @@
+<?php
+
+return [
+    'memory' => env('SIDECAR_BROWSERSHOT_MEMORY', 2048),
+
+    'warming' => env('SIDECAR_BROWSERSHOT_WARMING_INSTANCES', 0),
+
+    'layer' => env('SIDECAR_BROWSERSHOT_LAYER'),
+];

--- a/config/sidecar-browsershot.php
+++ b/config/sidecar-browsershot.php
@@ -1,9 +1,24 @@
 <?php
 
 return [
+    /**
+     * Define the allocated memory available to SidecarBrowsershot in megabytes. (Defaults to 2GB)
+     * We suggest to allocate at least 513 MB of memory to push Chrome/Puppeteer out of "low-spec" mode.
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/customization#memory
+     * @see https://github.blog/2021-06-22-framework-building-open-graph-images/
+     */
     'memory' => env('SIDECAR_BROWSERSHOT_MEMORY', 2048),
 
+    /**
+     * Define the number of warming instances to boot.
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/warming
+     */
     'warming' => env('SIDECAR_BROWSERSHOT_WARMING_INSTANCES', 0),
 
+    /**
+     * AWS Layer to use by Lambda. Defaults to "shelfio/chrome-aws-lambda-layer" in your AWS region.
+     * Must contain "chrome-aws-lambda".
+     * @see https://github.com/shelfio/chrome-aws-lambda-layer
+     */
     'layer' => env('SIDECAR_BROWSERSHOT_LAYER'),
 ];

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -5,6 +5,7 @@ namespace Wnx\SidecarBrowsershot\Functions;
 use Hammerstone\Sidecar\LambdaFunction;
 use Hammerstone\Sidecar\Package;
 use Hammerstone\Sidecar\Runtime;
+use Hammerstone\Sidecar\WarmingConfig;
 
 class BrowsershotFunction extends LambdaFunction
 {
@@ -57,16 +58,23 @@ class BrowsershotFunction extends LambdaFunction
 
     public function memory()
     {
-        return 2048;
+        return config('sidecar-browsershot.memory');
+    }
+
+    public function warmingConfig()
+    {
+        return WarmingConfig::instances(config('sidecar-browsershot.warming'));
     }
 
     public function layers()
     {
+        if ($layer = config('sidecar-browsershot.layer')) {
+            return [$layer];
+        }
+
         $region = config('sidecar.aws_region');
 
-        return [
-            // https://github.com/shelfio/chrome-aws-lambda-layer
-            "arn:aws:lambda:{$region}:764866452798:layer:chrome-aws-lambda:25",
-        ];
+        // https://github.com/shelfio/chrome-aws-lambda-layer
+        return ["arn:aws:lambda:{$region}:764866452798:layer:chrome-aws-lambda:25"];
     }
 }

--- a/src/SidecarBrowsershotServiceProvider.php
+++ b/src/SidecarBrowsershotServiceProvider.php
@@ -17,6 +17,7 @@ class SidecarBrowsershotServiceProvider extends PackageServiceProvider
          */
         $package
             ->name('sidecar-browsershot')
+            ->hasConfigFile()
             ->hasCommand(InternalBrowsershotSetupCommand::class);
     }
 }


### PR DESCRIPTION
This PR addresses #17 and #16 by adding a `sidecar-browsershot` config file which in turn is used in `BrowsershotFunction`.

Through the config, users can adjust

- memory
- warming instances
- layers