### PR TITLE
Update to newest aws chrome layer

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -1,6 +1,6 @@
 const fs = require('fs');
 const { execSync } = require('child_process');
-const chromium = require('chrome-aws-lambda');
+const chromium = require('@sparticuz/chrome-aws-lambda');
 const AWS = require('aws-sdk');
 
 exports.handle = async function (event) {

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -75,6 +75,6 @@ class BrowsershotFunction extends LambdaFunction
         $region = config('sidecar.aws_region');
 
         // https://github.com/shelfio/chrome-aws-lambda-layer
-        return ["arn:aws:lambda:{$region}:764866452798:layer:chrome-aws-lambda:25"];
+        return ["arn:aws:lambda:{$region}:764866452798:layer:chrome-aws-lambda:31"];
     }
 }

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -48,7 +48,7 @@ class BrowsershotFunction extends LambdaFunction
         $browser = str_replace('const puppet = (pup || require(\'puppeteer\'));', '', $browser);
 
         // Add ours.
-        return "const puppet = require('chrome-aws-lambda').puppeteer; \n" . $browser;
+        return "const puppet = require('@sparticuz/chrome-aws-lambda').puppeteer; \n" . $browser;
     }
 
     public function runtime()


### PR DESCRIPTION
If you take a look at https://github.com/shelfio/chrome-aws-lambda-layer/#getting-started you will see the newest chrome layer has an updated require statement (this began in version 26 as you can see here: https://github.com/shelfio/chrome-aws-lambda-layer/commit/02f73fe9e9733112daef420445000a72b0a33bf5#diff-5a831ea67cf5cf8703b0de46901ab25bd191f56b320053be9332d9a3b0d01d15R18)