### PR TITLE
Run Unit Tests in Serial Order on GitHub Actions

### DIFF
--- a/.github/workflows/reusable-run-test.yml
+++ b/.github/workflows/reusable-run-test.yml
@@ -1,0 +1,64 @@
+name: Run Tests
+
+on:
+  workflow_call:
+    inputs:
+      php_version:
+        required: true
+        type: string
+      laravel_version:
+        required: true
+        type: string
+      testbench_version:
+        required: true
+        type: string
+      stability:
+        required: true
+        type: string
+
+jobs:
+  example_job:
+    name: P${{ inputs.php_version }} - L${{ inputs.laravel_version }} - ${{ inputs.stability }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ inputs.php_version }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
+          coverage: pcov
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ inputs.laravel_version }}" "orchestra/testbench:${{ inputs.testbench_version }}" --no-interaction --no-update
+          composer update --${{ inputs.stability }} --prefer-dist --no-interaction
+
+        # Secrets used by vendor/bin/testbench have to be declared inside testbench.yaml. env() can't be used.
+      - name: Setup Testbench
+        run: |
+          echo "
+          providers:
+            - Hammerstone\Sidecar\Providers\SidecarServiceProvider
+            - Wnx\SidecarBrowsershot\SidecarBrowsershotServiceProvider" >> testbench.yaml
+
+        # Deploy Lambda function before running the test suite.
+      - name: Deploy Lambda function
+        run: vendor/bin/testbench sidecar-browsershot:setup --no-interaction -vvv
+        env:
+          SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+          SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+          SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+          SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+          SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
+
+      - name: Execute tests
+        run: vendor/bin/pest --coverage
+        env:
+          SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+          SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+          SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+          SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+          SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}

--- a/.github/workflows/reusable-run-test.yml
+++ b/.github/workflows/reusable-run-test.yml
@@ -15,6 +15,18 @@ on:
       stability:
         required: true
         type: string
+    secrets:
+      SIDECAR_ACCESS_KEY_ID:
+        required: true
+      SIDECAR_SECRET_ACCESS_KEY:
+        required: true
+      SIDECAR_REGION:
+        required: true
+      SIDECAR_ARTIFACT_BUCKET_NAME:
+        required: true
+      SIDECAR_EXECUTION_ROLE:
+        required: true
+
 
 jobs:
   test:

--- a/.github/workflows/reusable-run-test.yml
+++ b/.github/workflows/reusable-run-test.yml
@@ -17,7 +17,7 @@ on:
         type: string
 
 jobs:
-  example_job:
+  test:
     name: P${{ inputs.php_version }} - L${{ inputs.laravel_version }} - ${{ inputs.stability }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -7,62 +7,82 @@ on:
     branches: [main]
 
 jobs:
-  test:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: true
-      matrix:
-        os: [ubuntu-latest]
-        php: [8.0, 8.1]
-        laravel: [8.*, 9.*]
-        stability: [prefer-lowest, prefer-stable]
-        include:
-          - laravel: 8.*
-            testbench: ^6.23
-          - laravel: 9.*
-            testbench: ^7.0
-
-    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
-
+  php-8-laravel-8-lowest:
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+      - uses: ./.github/workflows/reusable-run-test.yml
         with:
-          php-version: ${{ matrix.php }}
-          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick, fileinfo
-          coverage: pcov
+          php_version: 8.0
+          laravel_version: 8.*
+          testbench_version: ^6.23
+          stability: prefer-lowest
 
-      - name: Install dependencies
-        run: |
-          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
-          composer update --${{ matrix.stability }} --prefer-dist --no-interaction
+  php-8-laravel-8-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.0
+          laravel_version: 8.*
+          testbench_version: ^6.23
+          stability: prefer-stable
 
-        # Secrets used by vendor/bin/testbench have to be declared inside testbench.yaml. env() can't be used.
-      - name: Setup Testbench
-        run: |
-          echo "
-          providers:
-            - Hammerstone\Sidecar\Providers\SidecarServiceProvider
-            - Wnx\SidecarBrowsershot\SidecarBrowsershotServiceProvider" >> testbench.yaml
+  php-8-laravel-9-lowest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.0
+          laravel_version: 9.*
+          testbench_version: ^7.0
+          stability: prefer-lowest
 
-        # Deploy Lambda function before running the test suite.
-      - name: Deploy Lambda function
-        run: vendor/bin/testbench sidecar-browsershot:setup --no-interaction -vvv
-        env:
-          SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
-          SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
-          SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
-          SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
-          SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
+  php-8-laravel-9-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.0
+          laravel_version: 9.*
+          testbench_version: ^7.0
+          stability: prefer-stable
 
-      - name: Execute tests
-        run: vendor/bin/pest --coverage
-        env:
-          SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
-          SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
-          SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
-          SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
-          SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
+  php-81-laravel-8-lowest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.1
+          laravel_version: 8.*
+          testbench_version: ^6.23
+          stability: prefer-lowest
+
+  php-81-laravel-8-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.1
+          laravel_version: 8.*
+          testbench_version: ^6.23
+          stability: prefer-stable
+
+  php-81-laravel-9-lowest:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.1
+          laravel_version: 9.*
+          testbench_version: ^7.0
+          stability: prefer-lowest
+
+  php-81-laravel-9-stable:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: ./.github/workflows/reusable-run-test.yml
+        with:
+          php_version: 8.1
+          laravel_version: 9.*
+          testbench_version: ^7.0
+          stability: prefer-stable

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -6,83 +6,68 @@ on:
   pull_request:
     branches: [main]
 
+
 jobs:
   php-8-laravel-8-lowest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.0
-          laravel_version: 8.*
-          testbench_version: ^6.23
-          stability: prefer-lowest
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.0
+      laravel_version: 8.*
+      testbench_version: ^6.23
+      stability: prefer-lowest
 
   php-8-laravel-8-stable:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.0
-          laravel_version: 8.*
-          testbench_version: ^6.23
-          stability: prefer-stable
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.0
+      laravel_version: 8.*
+      testbench_version: ^6.23
+      stability: prefer-stable
 
   php-8-laravel-9-lowest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.0
-          laravel_version: 9.*
-          testbench_version: ^7.0
-          stability: prefer-lowest
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.0
+      laravel_version: 9.*
+      testbench_version: ^7.0
+      stability: prefer-lowest
 
   php-8-laravel-9-stable:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.0
-          laravel_version: 9.*
-          testbench_version: ^7.0
-          stability: prefer-stable
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.0
+      laravel_version: 9.*
+      testbench_version: ^7.0
+      stability: prefer-stable
 
   php-81-laravel-8-lowest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.1
-          laravel_version: 8.*
-          testbench_version: ^6.23
-          stability: prefer-lowest
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.1
+      laravel_version: 8.*
+      testbench_version: ^6.23
+      stability: prefer-lowest
 
   php-81-laravel-8-stable:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.1
-          laravel_version: 8.*
-          testbench_version: ^6.23
-          stability: prefer-stable
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.1
+      laravel_version: 8.*
+      testbench_version: ^6.23
+      stability: prefer-stable
 
   php-81-laravel-9-lowest:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.1
-          laravel_version: 9.*
-          testbench_version: ^7.0
-          stability: prefer-lowest
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.1
+      laravel_version: 9.*
+      testbench_version: ^7.0
+      stability: prefer-lowest
 
   php-81-laravel-9-stable:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: ./.github/workflows/reusable-run-test.yml
-        with:
-          php_version: 8.1
-          laravel_version: 9.*
-          testbench_version: ^7.0
-          stability: prefer-stable
+    uses: ./.github/workflows/reusable-run-test.yml
+    with:
+      php_version: 8.1
+      laravel_version: 9.*
+      testbench_version: ^7.0
+      stability: prefer-stable

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,6 +15,12 @@ jobs:
       laravel_version: 8.*
       testbench_version: ^6.23
       stability: prefer-lowest
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-8-laravel-8-stable:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -23,6 +29,12 @@ jobs:
       laravel_version: 8.*
       testbench_version: ^6.23
       stability: prefer-stable
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-8-laravel-9-lowest:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -31,6 +43,12 @@ jobs:
       laravel_version: 9.*
       testbench_version: ^7.0
       stability: prefer-lowest
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-8-laravel-9-stable:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -39,6 +57,12 @@ jobs:
       laravel_version: 9.*
       testbench_version: ^7.0
       stability: prefer-stable
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-81-laravel-8-lowest:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -47,6 +71,12 @@ jobs:
       laravel_version: 8.*
       testbench_version: ^6.23
       stability: prefer-lowest
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-81-laravel-8-stable:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -55,6 +85,12 @@ jobs:
       laravel_version: 8.*
       testbench_version: ^6.23
       stability: prefer-stable
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-81-laravel-9-lowest:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -63,6 +99,12 @@ jobs:
       laravel_version: 9.*
       testbench_version: ^7.0
       stability: prefer-lowest
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}
 
   php-81-laravel-9-stable:
     uses: ./.github/workflows/reusable-run-test.yml
@@ -71,3 +113,9 @@ jobs:
       laravel_version: 9.*
       testbench_version: ^7.0
       stability: prefer-stable
+    secrets:
+      SIDECAR_ACCESS_KEY_ID: ${{secrets.SIDECAR_ACCESS_KEY_ID}}
+      SIDECAR_SECRET_ACCESS_KEY: ${{secrets.SIDECAR_SECRET_ACCESS_KEY}}
+      SIDECAR_REGION: ${{secrets.SIDECAR_REGION}}
+      SIDECAR_ARTIFACT_BUCKET_NAME: ${{secrets.SIDECAR_ARTIFACT_BUCKET_NAME}}
+      SIDECAR_EXECUTION_ROLE: ${{secrets.SIDECAR_EXECUTION_ROLE}}


### PR DESCRIPTION
Tests for this package for different PHP and Laravel versions need to be run in serial than in parallel. Running the tests in a Matrix leads to race conditions on AWS.