### PR TITLE
Use GitHub Actions max-parallel setting to run tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     # concurrency: ci-${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
-      # fail-fast: true
+      fail-fast: false
       max-parallel: 1
       matrix:
         os: [ubuntu-latest]
@@ -23,6 +23,10 @@ jobs:
             testbench: ^6.23
           - laravel: 9.*
             testbench: ^7.0
+        exclude:
+          - laravel: 8.*
+            php: 8.0
+            stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,10 +8,11 @@ on:
 
 jobs:
   test:
-    concurrency: ci-${{ github.ref }}
+    # concurrency: ci-${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true
+      max-parallel: 1
       matrix:
         os: [ubuntu-latest]
         php: [8.0, 8.1]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -11,7 +11,7 @@ jobs:
     # concurrency: ci-${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      # fail-fast: true
       max-parallel: 1
       matrix:
         os: [ubuntu-latest]

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -25,7 +25,6 @@ jobs:
             testbench: ^7.0
         exclude:
           - laravel: 8.*
-            php: 8.0
             stability: prefer-lowest
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,7 +8,6 @@ on:
 
 jobs:
   test:
-    # concurrency: ci-${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   test:
+    concurrency: ci-${{ github.ref }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: true


### PR DESCRIPTION
#28 doesn't seem to work as I want it. Luckily GitHub Actions seems to have a Concurrency settings which should be helpful in this repo. 

- https://docs.github.com/en/actions/using-jobs/using-concurrency
- https://docs.github.com/en/actions/examples/using-concurrency-expressions-and-a-test-matrix

---

Scrap that, all we need to set is `max-parallel: 1`. 🎉 