### PR TITLE
Trim base64 PDF Response by overriding base64pdf method

### DIFF
--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -86,4 +86,11 @@ class BrowsershotLambda extends Browsershot
 
         return $output;
     }
+
+    public function base64pdf(): string
+    {
+        $command = $this->createPdfCommand();
+
+        return rtrim($this->callBrowser($command));
+    }
 }

--- a/tests/BrowsershotLambdaTest.php
+++ b/tests/BrowsershotLambdaTest.php
@@ -96,3 +96,12 @@ test('it throws CouldNotTakeBrowsershot Exception if no file extension is passed
     BrowsershotLambda::html('<h1>Hello world!!</h1>')
         ->saveToS3('example');
 })->expectException(CouldNotTakeBrowsershot::class);
+
+it('returns a trimed base64pdf', function () {
+    $base64 = BrowsershotLambda::html('<h1>Hello world!!</h1>')
+        ->base64pdf();
+
+    $decode = base64_decode($base64);
+
+    $this->assertEquals($base64, base64_encode($decode));
+});


### PR DESCRIPTION
Hi, as mentioned in #34 trimming the returned response ensured the return string can be decoded and encoded.