### PR TITLE
Use sidecar.aws_region value in saveToS3 method

### DIFF
--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -64,7 +64,7 @@ class BrowsershotLambda extends Browsershot
     {
         $this->setOption('s3', [
             'path' => $targetPath,
-            'region' => config('sidecar.region'),
+            'region' => config('sidecar.aws_region'),
             'bucket' => config("filesystems.disks.$disk.bucket"),
         ]);
 


### PR DESCRIPTION
While using the `saveToS3()` method in one of my own projects, I've noticed that `BrowsershotLambda` referenced the `sidecar.region`-config key. That should have been `sidecar.aws_region` the whole time.