### PR TITLE
Cleanup puppeteer_dev_chrome_profile folders in tmp after running Puppeteer 

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -48,6 +48,13 @@ exports.handle = async function (event) {
         maxBuffer: 1024 * 1024 * 100
     });
 
+    // Delete puppeteer profiles from temp directory to free up space
+    fs.readdirSync('/tmp').forEach(file => {
+        if (file.startsWith('puppeteer_dev_chrome_profile')) {
+            fs.rmdirSync(`/tmp/${file}`, { recursive: true });
+        }
+    });
+
     // If there was a path, then read the file and return it.
     if (event.options.path) {
         let contents = fs.readFileSync(event.options.path);


### PR DESCRIPTION
This PR tackles #30 and exceptions like these:

> Lambda Execution Exception for Wnx\SidecarBrowsershot\Functions\BrowsershotFunction: "ENOSPC: no space left on device, write. [TRACE] Error: ENOSPC: no space left on device, write at Object.writeSync (fs.js:737:3) at Object.writeFileSync (fs.js:1535:26)".

Chromium / Puppeteer generates a profile in `/tmp` that keeps lying around between Lambda executions. These profiles can accumulate and exhaust the default "ephemeral storage" of 512MB. Execution the Lambda again in short succession will lead to the error above.

This PR tries to resolve this problem by removing any `puppeteer_dev_chrome_profile-*`-folders after the Browsershot is finished.

## Related Issues

- https://github.com/stefanzweifel/sidecar-browsershot/issues/30
- https://github.com/puppeteer/puppeteer/issues/6414
- https://github.com/puppeteer/puppeteer/issues/6286
- https://github.com/mifi/reactive-video/issues/11
- https://github.com/puppeteer/puppeteer/issues/6291