### PR TITLE
Store Emoji Font in package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,4 +13,3 @@ vendor
 node_modules
 .php-cs-fixer.cache
 .env
-/resources/lambda/NotoColorEmoji.ttf

--- a/bin/download-emoji-font.sh
+++ b/bin/download-emoji-font.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+DOWNLOAD_URL=https://raw.githubusercontent.com/googlefonts/noto-emoji/main/fonts/NotoColorEmoji.ttf
+
+curl -o resources/lambda/NotoColorEmoji.ttf $DOWNLOAD_URL

--- a/composer.json
+++ b/composer.json
@@ -52,7 +52,8 @@
     "scripts": {
         "analyse": "vendor/bin/phpstan analyse",
         "test": "vendor/bin/pest",
-        "test-coverage": "vendor/bin/pest --coverage"
+        "test-coverage": "vendor/bin/pest --coverage",
+        "download-emoji-font": "sh ./bin/download-emoji-font.sh"
     },
     "config": {
         "sort-packages": true,

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -78,14 +78,4 @@ class BrowsershotFunction extends LambdaFunction
         // https://github.com/shelfio/chrome-aws-lambda-layer
         return ["arn:aws:lambda:{$region}:764866452798:layer:chrome-aws-lambda:31"];
     }
-
-    public function beforeDeployment()
-    {
-        // Download NotoColorEmoji font to support rendering emojis in Browsershot.
-        // A fresh font file is downloaded, when the font file is not present.
-        if (! file_exists(__DIR__ . '/../../resources/lambda/NotoColorEmoji.ttf')) {
-            $font = file_get_contents('https://raw.githubusercontent.com/googlefonts/noto-emoji/main/fonts/NotoColorEmoji.ttf');
-            file_put_contents(__DIR__ . '/../../resources/lambda/NotoColorEmoji.ttf', $font);
-        }
-    }
 }


### PR DESCRIPTION
This PR reverts some changes I made in #51. 
We now add the `NotoColorEmoji.ttf`-file in the repository and will periodically update the file, instead of letting the user download the file, when they deploy their Sidecar function.

This resolves an issue for users on Laravel Vapor.
Closes #55