### PR TITLE
Sidecar 0.4.0 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.0",
-        "hammerstone/sidecar": "^0.3.7",
+        "hammerstone/sidecar": "^0.4.0",
         "illuminate/contracts": "^8.0|^9.0|^10.0",
         "spatie/browsershot": "^3.52",
         "spatie/laravel-package-tools": "^1.9.2"


### PR DESCRIPTION
This PR adds [sidecar v0.4.0](https://github.com/hammerstonedev/sidecar/releases/tag/v0.4.0) support.

Currently, it is not possible to update project's sidecar version because of version constrains on sidecar-browsershot.

`composer why-not hammerstone/sidecar 0.4.0` command outputs:

```
wnx/sidecar-browsershot v1.6.3 requires hammerstone/sidecar (^0.3.7)
```