### PR TITLE
Read source file from s3

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,21 @@ SIDECAR_BROWSERSHOT_WARMING_INSTANCES=5
 
 Alternatively you can publish the `sidecar-browsershot.php` config file and change the `warming` setting yourself.
 
+## Reading source from S3
+
+You can store a HTML file on AWS S3 and pass the path to Lambda for it to create the PDF or image from. 
+This is necessary for large source files in order to avoid restrictions on the size of Lambda requests.
+
+```php
+use Wnx\SidecarBrowsershot\BrowsershotLambda;
+
+// Use a HTML file from S3 to generate a PDF
+BrowsershotLambda::htmlFromS3File('html/example.html')->save('example.pdf');
+
+// You can also pass a disk name if required (default: 's3')
+BrowsershotLambda::htmlFromS3File('html/example.html', 's3files')->save('example.pdf');
+```
+
 ## Saving directly to S3
 
 You can store your file directly on AWS S3 if you want to keep it there, or to avoid the size limit on Lambda responses.

--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -87,6 +87,24 @@ class BrowsershotLambda extends Browsershot
         return $output;
     }
 
+    /**
+     * Load the html from a file that is stored in S3.
+     *
+     * @param string $sourcePath
+     * @param string $disk
+     *
+     * @return static
+     */
+    public static function htmlFromS3File(string $sourcePath, string $disk = 's3'): self
+    {
+        return (new static())
+            ->setOption('s3Source', [
+                'path' => $sourcePath,
+                'region' => config('sidecar.aws_region'),
+                'bucket' => config("filesystems.disks.$disk.bucket"),
+            ]);
+    }
+
     public function base64pdf(): string
     {
         $command = $this->createPdfCommand();

--- a/tests/BrowsershotLambdaTest.php
+++ b/tests/BrowsershotLambdaTest.php
@@ -104,3 +104,13 @@ it('returns a trimed base64pdf', function () {
 
     $this->assertEquals($base64, base64_encode($decode));
 });
+
+it('reads a file from an s3 bucket', function () {
+    // Create test file in s3 bucket
+    Storage::disk('s3')->put('example.html', '<h1>Hello world!!</h1>');
+    $this->assertTrue(Storage::disk('s3')->exists('example.html'));
+
+    BrowsershotLambda::htmlFromS3File('example.html')->save('example.pdf');
+
+    $this->assertFileExists('example.pdf');
+});


### PR DESCRIPTION
Added support to read source html file from s3.

This helps overcome limitations with the size of Lambda requests where the source HTML is larger than the request would otherwise allow.
