### PR TITLE
Added storage config setting

### DIFF
--- a/config/sidecar-browsershot.php
+++ b/config/sidecar-browsershot.php
@@ -10,6 +10,12 @@ return [
     'memory' => env('SIDECAR_BROWSERSHOT_MEMORY', 2048),
 
     /**
+     * The default ephemeral storage available to SidecarBrowsershot, in megabytes. (Defaults to 512MB)
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/customization#storage
+     */
+    'storage' => env('SIDECAR_BROWSERSHOT_STORAGE', 512),
+
+    /**
      * Define the number of warming instances to boot.
      * @see https://hammerstone.dev/sidecar/docs/main/functions/warming
      */

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -62,6 +62,15 @@ class BrowsershotFunction extends LambdaFunction
         return config('sidecar-browsershot.memory');
     }
 
+    /**
+     * @inheritDoc
+     */
+    public function storage()
+    {
+        // Default to the main sidecar config value if the sidecar-browsershot config hasn't been updated to include this new key.
+        return config('sidecar-browsershot.storage', parent::storage());
+    }
+
     public function warmingConfig()
     {
         return WarmingConfig::instances(config('sidecar-browsershot.warming'));


### PR DESCRIPTION
Added a config item to allow the changing of the ephemeral storage value, used when deploying sidecar-browsershot.

The storage method, which is used by sidecar, returns the value as set in the config. If the config item does not exist, for example if the config has not been updated after this release, the default sidecar value is used.
