### PR TITLE
Only support x86_64 architecture

### DIFF
--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -2,6 +2,7 @@
 
 namespace Wnx\SidecarBrowsershot\Functions;
 
+use Hammerstone\Sidecar\Architecture;
 use Hammerstone\Sidecar\LambdaFunction;
 use Hammerstone\Sidecar\Package;
 use Hammerstone\Sidecar\Runtime;
@@ -69,6 +70,14 @@ class BrowsershotFunction extends LambdaFunction
     {
         // Default to the main sidecar config value if the sidecar-browsershot config hasn't been updated to include this new key.
         return config('sidecar-browsershot.storage', parent::storage());
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function architecture()
+    {
+        return Architecture::X86_64;
     }
 
     public function warmingConfig()


### PR DESCRIPTION
Puppeteer does not officially support arm (https://github.com/puppeteer/puppeteer/issues/7740) yet. 
To prevent future issues we're going to hardcode the architecture to always be x86_64.