### PR TITLE
Add Support for Image Manipulations when using `saveToS3`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,28 @@ BrowsershotLambda::url('https://example.com')->saveToS3('example.pdf');
 BrowsershotLambda::html('<h1>Hello world!!</h1>')->saveToS3('example.pdf', 'example-store');
 ```
 
+## Image Manipulation
+Like the original Browsershot package, you can [manipulate the image](https://spatie.be/docs/browsershot/v2/usage/creating-images#content-sizing-the-image) size and format.
+
+> **Note**   
+> If you're using `fit()` in combination with `saveToS3`, the image will be downloaded from S3 to your local disc, manipulated and then uploaded back to S3.
+
+```php
+// Take screenshot at 1920x1080 and scale it down to fit 200x200 
+BrowsershotLambda::url('https://example.com')
+    ->windowSize(1920, 1080)
+    ->fit(Manipulations::FIT_CONTAIN, 200, 200)
+    ->save('example.jpg');
+    
+// Take screenshot at 1920x1080 and scale it down to fit 200x200 and save it on S3
+// Note: To do the image manipulation, BrowsershotLambda will download the image
+// from S3 to the local disc of your app, manipulate it and then upload it back to S3. 
+BrowsershotLambda::url('https://example.com')
+    ->windowSize(1920, 1080)
+    ->fit(Manipulations::FIT_CONTAIN, 200, 200)
+    ->saveToS3('example.jpg');
+```
+
 ## Testing
 
 The testsuite makes connections to AWS and runs the deployed Lambda function. In order to run the testsuite, you will need an active [AWS account](https://aws.amazon.com/).

--- a/tests/BrowsershotLambdaTest.php
+++ b/tests/BrowsershotLambdaTest.php
@@ -118,7 +118,7 @@ it('reads a file from an s3 bucket', function () {
 });
 
 it('applies image manipulations when calling save method', function () {
-     $this->assertFileDoesNotExist('example.jpg');
+    $this->assertFileDoesNotExist('example.jpg');
 
     BrowsershotLambda::url('https://example.com')
         ->windowSize(1920, 1080)

--- a/tests/BrowsershotLambdaTest.php
+++ b/tests/BrowsershotLambdaTest.php
@@ -3,6 +3,8 @@
 use Hammerstone\Sidecar\Exceptions\LambdaExecutionException;
 use Illuminate\Support\Facades\Storage;
 use Spatie\Browsershot\Exceptions\CouldNotTakeBrowsershot;
+use Spatie\Image\Image;
+use Spatie\Image\Manipulations;
 use Wnx\SidecarBrowsershot\BrowsershotLambda;
 
 beforeEach(function () {
@@ -114,3 +116,16 @@ it('reads a file from an s3 bucket', function () {
 
     $this->assertFileExists('example.pdf');
 });
+
+it('applies image manipulations when calling save method', function () {
+     $this->assertFileDoesNotExist('example.jpg');
+
+    BrowsershotLambda::url('https://example.com')
+        ->windowSize(1920, 1080)
+        ->fit(Manipulations::FIT_CONTAIN, 200, 200)
+        ->save('example.jpg');
+
+    $image = new Image('example.jpg');
+    $this->assertEquals(200, $image->getWidth());
+});
+


### PR DESCRIPTION
This PR adds support for [Image Manipulation](https://spatie.be/docs/browsershot/v2/usage/creating-images#content-sizing-the-image) to sidecar-browsershot, when using the `saveToS3()`-method.
(This missing features was mentioned in #70.)

---

As we can't run image manipulation directly on S3[^1], we have to download the generated image from S3 to a local disk, apply the manipulations and then re-upload the file again to S3 and delete the local copy.

This _works_, but I would have preferred if we could just point the S3 path/url to the `Image`-class. But that's the tradeoff one has to make when running Browsershot on AWS Lambda, I guess. 🤷 

[^1]: The [spatie/image](https://github.com/spatie/image) package requires the image to be available in the local filesystem where PHP is run. `sidecar-browsershot` runs JavaScript on Lambda and not PHP.