### PR TITLE
Fix browser.js file renamed in browsershot 3.57.8

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -61,7 +61,7 @@ exports.handle = async function (event) {
     fs.writeFileSync(options, JSON.stringify(event));
 
     // Exec spatie's browser command.
-    let result = execSync(`node ./browser.js '-f file://${options}'`, {
+    let result = execSync(`node ./browser.cjs '-f file://${options}'`, {
         // Set maxBuffer to 100 MB
         maxBuffer: 1024 * 1024 * 100
     });

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -24,7 +24,7 @@ class BrowsershotFunction extends LambdaFunction
     {
         return Package::make()
             ->includeStrings([
-                'browser.js' => $this->modifiedBrowserJs(),
+                'browser.cjs' => $this->modifiedBrowserJs(),
             ])
             ->includeExactly([
                 __DIR__ . '/../../resources/lambda/browsershot.js' => 'browsershot.js',
@@ -34,16 +34,16 @@ class BrowsershotFunction extends LambdaFunction
 
     /**
      * We get puppeteer out of the layer, which spatie doesn't allow
-     * for. We'll just overwrite their browser.js to add it.
+     * for. We'll just overwrite their browser.cjs to add it.
      *
      * @return string
      */
     protected function modifiedBrowserJs()
     {
         if (app()->environment('testing')) {
-            $browser = file_get_contents('vendor/spatie/browsershot/bin/browser.js');
+            $browser = file_get_contents('vendor/spatie/browsershot/bin/browser.cjs');
         } else {
-            $browser = file_get_contents(base_path('vendor/spatie/browsershot/bin/browser.js'));
+            $browser = file_get_contents(base_path('vendor/spatie/browsershot/bin/browser.cjs'));
         }
 
         // Remove their reference.


### PR DESCRIPTION
The browser.js file was renamed to browser.cjs in https://github.com/spatie/browsershot/releases/tag/3.57.8 

This commit reflects the change.