### PR TITLE
Added a config item to allow the overriding of default timeout value

### DIFF
--- a/config/sidecar-browsershot.php
+++ b/config/sidecar-browsershot.php
@@ -16,6 +16,12 @@ return [
     'storage' => env('SIDECAR_BROWSERSHOT_STORAGE', 512),
 
     /**
+     * The default timeout to use for SidecarBrowsershot, in seconds. (Defaults to 300)
+     * @see https://hammerstone.dev/sidecar/docs/main/functions/customization#timeout
+     */
+    'timeout' => env('SIDECAR_BROWSERSHOT_TIMEOUT', 300),
+
+    /**
      * Define the number of warming instances to boot.
      * @see https://hammerstone.dev/sidecar/docs/main/functions/warming
      */

--- a/src/Functions/BrowsershotFunction.php
+++ b/src/Functions/BrowsershotFunction.php
@@ -74,6 +74,15 @@ class BrowsershotFunction extends LambdaFunction
     /**
      * @inheritDoc
      */
+    public function timeout()
+    {
+        // Defaults to the main sidecar config value if the sidecar-browsershot config hasn't been updated to include this new key.
+        return config('sidecar-browsershot.timeout', parent::timeout());
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function architecture()
     {
         return Architecture::X86_64;


### PR DESCRIPTION
Added the ability to be able to specify a timeout value specific to sidecar-browsershot, overriding the sidecar default value.

This is used when you need to change the AWS function timeout setting for sidecar-browsershot without affecting other projects running using sidecar. 

It uses the customisation function provided by sidecar as detailed in their documentation, in the same way that both the memory and storage configuration values have already been customized previously:
https://hammerstone.dev/sidecar/docs/main/functions/customization#timeout

Will fallback to the sidecar default value if the current sidecar-browsershot config hasn't got the new config key in it, for example if an updated config hasn't been published.