### PR TITLE
Add internal support for Chromium Result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^8.0",
         "hammerstone/sidecar": "^0.4.0",
         "illuminate/contracts": "^8.0|^9.0|^10.0",
-        "spatie/browsershot": "^3.57.8",
+        "spatie/browsershot": "^3.60",
         "spatie/laravel-package-tools": "^1.9.2"
     },
     "require-dev": {

--- a/src/BrowsershotLambda.php
+++ b/src/BrowsershotLambda.php
@@ -54,7 +54,7 @@ class BrowsershotLambda extends Browsershot
         }
 
         // If ChromiumResult is available, return the result from there.
-        if ($this->chromiumResult)  {
+        if ($this->chromiumResult) {
             return $this->chromiumResult->getResult();
         }
 

--- a/tests/BrowsershotLambdaTest.php
+++ b/tests/BrowsershotLambdaTest.php
@@ -62,7 +62,7 @@ it('returns raw html from url', function () {
 it('returns raw html from html', function () {
     $html = BrowsershotLambda::html('<h1>Hello world!!</h1>')->bodyHtml();
 
-    $this->assertEquals("<html><head></head><body><h1>Hello world!!</h1></body></html>\n", $html);
+    $this->assertEquals("<html><head></head><body><h1>Hello world!!</h1></body></html>", $html);
 });
 
 it('throws LambdaExecutionException error if browsershot fails', function () {


### PR DESCRIPTION
https://github.com/spatie/browsershot/pull/780 added a new `ChromiumResult`-class that is used internally by Browsershot.
This change lead to issues as described in #104.

This PR fixes these issues by inspecting the result from the Lambda run and  dealing with it accordingly.