### PR TITLE
Add Support for Laravel 11

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -15,11 +15,13 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         php: [8.2, 8.3]
-        laravel: [10.*]
+        laravel: [10.*, 11.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 10.*
             testbench: ^8.0
+          - laravel: 11.*
+            testbench: ^9.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php": "^8.2",
         "hammerstone/sidecar": "^0.4.0",
-        "illuminate/contracts": "^10.0",
+        "illuminate/contracts": "^10.0 || ^11.0",
         "spatie/browsershot": "^4.0",
         "spatie/laravel-package-tools": "^1.9.2"
     },
@@ -30,13 +30,13 @@
         "laravel/pint": "^1.13",
         "league/flysystem-aws-s3-v3": "^1.0|^2.0|^3.0",
         "nunomaduro/collision": "^7.0|^8.0",
-        "orchestra/testbench": "^8.0",
+        "orchestra/testbench": "^8.0|^9.0",
         "pestphp/pest": "^2.0",
         "pestphp/pest-plugin-laravel": "^2.0",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^10",
+        "phpunit/phpunit": "^10 | ^11.0",
         "spatie/image": "^3.3",
         "spatie/pixelmatch-php": "^1.0"
     },


### PR DESCRIPTION
This PR updates the package to support Laravel 11.

The `hammerstone/sidecar` package needs to support Laravel 11 as well, before this PR can be merged. A PR for this has been created: https://github.com/hammerstonedev/sidecar/pull/141