### PR TITLE
Use fs.rm instead of fs.rmdirSync to remove puppeteer profiles 

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -78,7 +78,7 @@ exports.handle = async function (event) {
     // Delete puppeteer profiles from temp directory to free up space
     fs.readdirSync('/tmp').forEach(file => {
         if (file.startsWith('puppeteer_dev_chrome_profile')) {
-            fs.rmdirSync(`/tmp/${file}`, { recursive: true });
+            fs.rm(`/tmp/${file}`, { recursive: true });
         }
     });
 


### PR DESCRIPTION
As reported in #110, AWS Lambda [throws](https://github.com/stefanzweifel/sidecar-browsershot/issues/110#issuecomment-1946504295) deprecations warnings about `fs.rmdirSync()`.

This PR updates `browsershot.js` to use `fs.rm()`.
