### PR TITLE
Fix support for Laravel 11

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "hammerstone/sidecar": "^0.5.0",
+        "hammerstone/sidecar": "^0.4 || ^0.5",
         "illuminate/contracts": "^10.0 || ^11.0",
         "spatie/browsershot": "^4.0",
         "spatie/laravel-package-tools": "^1.9.2"

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^8.2",
-        "hammerstone/sidecar": "^0.4.0",
+        "hammerstone/sidecar": "^0.5.0",
         "illuminate/contracts": "^10.0 || ^11.0",
         "spatie/browsershot": "^4.0",
         "spatie/laravel-package-tools": "^1.9.2"


### PR DESCRIPTION
PR fixes support for Laravel 11. Closes #119.

```
  Problem 1
    - wnx/sidecar-browsershot[v0.1.0, ..., v0.2.0, v1.0.0, ..., v1.6.3] require hammerstone/sidecar ^0.3.7 -> found hammerstone/sidecar[v0.3.7, ..., v0.3.12] but it conflicts with your root composer.json require (^0.5.0).
    - wnx/sidecar-browsershot[dev-fix/deprecated-node-methods, dev-feat/laravel-11, dev-main, v1.6.4, ..., v1.13.1, v2.0.0, ..., v2.3.0] require hammerstone/sidecar ^0.4.0 -> found hammerstone/sidecar[v0.4.0, v0.4.1, v0.4.2] but it conflicts with your root composer.json require (^0.5.0).
    - Root composer.json requires wnx/sidecar-browsershot * -> satisfiable by wnx/sidecar-browsershot[dev-fix/deprecated-node-methods, dev-feat/laravel-11, dev-main, v0.1.0, v0.2.0, v1.0.0, ..., v1.13.1, v2.0.0, v2.1.0, v2.2.0, v2.3.0, 9999999-dev].
```