### PR TITLE
Drop unsupported `chromium.font()` call

### DIFF
--- a/resources/lambda/browsershot.js
+++ b/resources/lambda/browsershot.js
@@ -15,11 +15,8 @@ exports.handle = async function (event) {
     // Disable webgl.
     chromium.setGraphicsMode = false;
 
-    // Add custom fonts to chromium.
-    const fontsFileNames = fs.readdirSync('/var/task/fonts/');
-    for (const fontFileName of fontsFileNames) {
-        await chromium.font(`/var/task/fonts/${fontFileName}`);
-    }
+    // Custom fonts are auto-loaded by @sparticuz/chromium from /var/task/fonts/
+    // (chromium.font() was removed in @sparticuz/chromium v144+)
 
     // Constant file where we write out options.
     const options = '/tmp/browsershot.js';


### PR DESCRIPTION
Fix for:
<img width="1296" height="176" alt="image" src="https://github.com/user-attachments/assets/fa834f00-949f-4ad6-ad64-bfeaa1f1d75b" />

----

This PR fixes a dropped `chromium.font()` function in [chromium v144.0.4](https://github.com/Sparticuz/chromium/commit/6be14440bfb0b6eb019605ece3854e75b8b57108)

Layers in use:
- arn:aws:lambda:eu-west-1:821527532446:layer:sidecar-browsershot-layer:4
- arn:aws:lambda:eu-west-1:764866452798:layer:chrome-aws-lambda:110